### PR TITLE
Fixed an error when setting player global position

### DIFF
--- a/scripts/gamestate.gd
+++ b/scripts/gamestate.gd
@@ -86,9 +86,9 @@ remote func pre_start_game(spawn_points):
 
 		player.set_name(str(p_id)) # Use unique ID as node name
 		player.set_network_master(p_id) #set unique id as master
-		player.global_transform.origin = spawn_pos
 		
 		main.get_node("players").add_child(player)
+		player.global_transform.origin = spawn_pos
 
 	if not get_tree().is_network_server():
 		# Tell server we are ready to start


### PR DESCRIPTION
The player global position is being set before it's added to the tree so it throws an error. To fix this, the player must be a child of the `players` node before it's global position is set, so I moved the positioning code after the `add_child` function is called.
Based on this solution to a similar problem: https://github.com/godotengine/godot/issues/22596#issuecomment-426079504